### PR TITLE
Add role-based navigation with earnings pages

### DIFF
--- a/app/kid/earnings/page.tsx
+++ b/app/kid/earnings/page.tsx
@@ -1,0 +1,25 @@
+import { supabaseServer } from '@/lib/supabase/server'
+import { Money } from '@/components/money'
+
+async function loadData() {
+    const sb = supabaseServer()
+    const { data: { user } } = await sb.auth.getUser()
+    if (!user) return null
+    const { data } = await sb.from('vw_kid_balances').select('*').eq('kid_id', user.id).single()
+    if (!data) return null
+    return data
+}
+
+export default async function KidEarningsPage() {
+    const balance = await loadData()
+    if (!balance) return <div>Please login</div>
+    return (
+        <div className="space-y-4">
+            <h1 className="text-2xl font-bold">My earnings</h1>
+            <div className="card flex justify-between">
+                <span>Total earned</span>
+                <span><Money value={Number(balance.balance_dollars)} /></span>
+            </div>
+        </div>
+    )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,20 @@
 import './globals.css'
 import Link from 'next/link'
+import { supabaseServer } from '@/lib/supabase/server'
 
 export const metadata = {
     title: 'ChoreApp',
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+    const sb = supabaseServer()
+    const { data: { user } } = await sb.auth.getUser()
+    let role: string | null = null
+    if (user) {
+        const { data: profile } = await sb.from('profiles').select('role').eq('id', user.id).single()
+        role = profile?.role ?? null
+    }
+
     return (
         <html lang="en">
         <body className="flex justify-center">
@@ -13,9 +22,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="container py-3 flex items-center gap-4">
                 <Link href="/" className="font-bold">ChoreApp</Link>
                 <nav className="flex items-center gap-3 text-sm">
-                    <Link href="/kid" className="hover:underline">Kid</Link>
-                    <Link href="/parent" className="hover:underline">Parent</Link>
-                    <Link href="/login" className="ml-auto hover:underline">Login</Link>
+                    {role === 'parent' && (
+                        <>
+                            <Link href="/parent" className="hover:underline">Chore Admin</Link>
+                            <Link href="/parent/earnings" className="hover:underline">Kids' Earnings</Link>
+                        </>
+                    )}
+                    {role === 'kid' && (
+                        <>
+                            <Link href="/kid" className="hover:underline">My Chores</Link>
+                            <Link href="/kid/earnings" className="hover:underline">My Earnings</Link>
+                        </>
+                    )}
+                    {!user && <Link href="/login" className="ml-auto hover:underline">Login</Link>}
                 </nav>
             </div>
         </header>

--- a/app/parent/actions.ts
+++ b/app/parent/actions.ts
@@ -36,6 +36,7 @@ export async function verifyCheckin(id: string) {
 export async function payKid(householdId: string, kidId: string) {
     const sb = supabaseServer()
     const { error } = await sb.rpc('create_full_payout_for_kid', { hh: householdId, kid: kidId })
-    if (error) redirect('/parent?flash=' + encodeURIComponent('Payout failed') + '&t=error')
-    redirect('/parent?flash=' + encodeURIComponent('Payout recorded') + '&t=success')
+    const base = '/parent/earnings'
+    if (error) redirect(base + '?flash=' + encodeURIComponent('Payout failed') + '&t=error')
+    redirect(base + '?flash=' + encodeURIComponent('Payout recorded') + '&t=success')
 }

--- a/app/parent/earnings/page.tsx
+++ b/app/parent/earnings/page.tsx
@@ -1,0 +1,55 @@
+import FlashBanner from '@/components/flash-banner'
+import { Money } from '@/components/money'
+import { supabaseServer } from '@/lib/supabase/server'
+import { payKid } from '../actions'
+
+async function loadData() {
+    const sb = supabaseServer()
+    const { data: { user } } = await sb.auth.getUser()
+    if (!user) return null
+
+    const { data: profile } = await sb.from('profiles').select('id, household_id').eq('id', user.id).single()
+    if (!profile) return null
+
+    const [kidsRes, balRes] = await Promise.all([
+        sb.from('profiles').select('id, display_name').neq('role','parent'),
+        sb.from('vw_kid_balances').select('*'),
+    ])
+
+    return { profile, kids: kidsRes.data ?? [], balances: balRes.data ?? [] }
+}
+
+export default async function ParentEarningsPage({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
+    const data = await loadData()
+    if (!data) return <div>Please login</div>
+    const { profile, kids, balances } = data
+
+    const message = typeof searchParams?.flash === 'string' ? searchParams.flash : undefined
+    const t = (searchParams?.t as 'success' | 'warn' | 'error') ?? 'success'
+
+    return (
+        <div className="space-y-8">
+            {message && <FlashBanner message={decodeURIComponent(message)} type={t} />}
+            <h1 className="text-2xl font-bold">Kids' earnings</h1>
+            <section className="card">
+                <h2 className="text-lg font-semibold mb-3">Balances</h2>
+                <table className="table">
+                    <thead><tr><th>Kid</th><th>Balance</th><th></th></tr></thead>
+                    <tbody>
+                    {balances.map((b: any) => (
+                        <tr key={b.kid_id}>
+                            <td>{(kids.find(k => k.id === b.kid_id)?.display_name) ?? b.kid_id}</td>
+                            <td><Money value={Number(b.balance_dollars)} /></td>
+                            <td>
+                                <form action={async () => { 'use server'; await payKid(profile.household_id, b.kid_id) }}>
+                                    <button className="btn" type="submit">Pay now</button>
+                                </form>
+                            </td>
+                        </tr>
+                    ))}
+                    </tbody>
+                </table>
+            </section>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
- Show role-aware navigation links for parents and kids
- Add parent earnings page for viewing and paying kids' balances
- Add kid earnings page to view individual balance
- Remove balances from chore admin page and adjust payout redirect

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=true npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a13fafc8328859063280a06088d