### PR TITLE
feat: adopt crypto theme styles

### DIFF
--- a/components/chore-card.tsx
+++ b/components/chore-card.tsx
@@ -2,13 +2,17 @@ import { Money } from './money'
 
 export function ChoreCard({ title, amount, dueTime, isAnyone }: { title: string; amount: number; dueTime?: string | null; isAnyone?: boolean }) {
     return (
-        <div className="card flex items-center justify-between">
-            <div>
-                <div className="text-lg font-semibold">{title} {isAnyone && <span className="badge ml-2">Anyone</span>}</div>
-                {dueTime && <div className="text-sm text-slate-500">Due by {dueTime}</div>}
-            </div>
-            <div className="text-right">
-                <Money value={amount} />
+        <div className="rounded-2xl bg-gradient-to-r from-gradient-start to-gradient-end p-px">
+            <div className="flex items-center justify-between rounded-2xl bg-slate-900 p-4">
+                <div>
+                    <div className="text-lg font-semibold text-primary">
+                        {title} {isAnyone && <span className="badge ml-2">Anyone</span>}
+                    </div>
+                    {dueTime && <div className="text-sm text-secondary">Due by {dueTime}</div>}
+                </div>
+                <div className="text-right text-primary">
+                    <Money value={amount} />
+                </div>
             </div>
         </div>
     )

--- a/components/flash-banner.tsx
+++ b/components/flash-banner.tsx
@@ -8,12 +8,19 @@ export default function FlashBanner({ message, type = 'success' }: { message: st
         return () => clearTimeout(t)
     }, [])
     if (!open) return null
-    const color = type === 'error' ? 'flash-error' : type === 'warn' ? 'flash-warn' : 'flash-success'
+    const color =
+        type === 'error'
+            ? 'from-secondary to-rose-600'
+            : type === 'warn'
+            ? 'from-amber-400 to-secondary'
+            : 'from-gradient-start to-gradient-end'
     return (
-        <div className={`flash-banner ${color}`} role="status" aria-live="polite">
+        <div className={`flash-banner bg-gradient-to-r ${color}`} role="status" aria-live="polite">
             <div className="flex items-center gap-3">
                 <span>{message}</span>
-                <button type="button" className="ml-2 rounded-lg bg-white/20 px-2 py-1" onClick={() => setOpen(false)}>✕</button>
+                <button type="button" className="ml-2 rounded-lg bg-slate-900/20 px-2 py-1" onClick={() => setOpen(false)}>
+                    ✕
+                </button>
             </div>
         </div>
     )

--- a/components/form.tsx
+++ b/components/form.tsx
@@ -3,5 +3,12 @@ import { useTransition } from 'react'
 
 export function SubmitButton({ pendingText = 'Saving…', children }: { pendingText?: string; children: React.ReactNode }) {
     const [pending] = useTransition()
-    return <button className="btn" disabled={pending}>{pending ? pendingText : children}</button>
+    return (
+        <button
+            className="relative inline-flex items-center justify-center rounded-xl px-4 py-2 font-semibold text-primary bg-slate-900 transition-colors before:absolute before:inset-0 before:-z-10 before:rounded-xl before:bg-gradient-to-r before:from-gradient-start before:to-gradient-end before:blur before:opacity-75 hover:text-slate-900 hover:bg-gradient-to-r hover:from-gradient-start hover:to-gradient-end disabled:opacity-50"
+            disabled={pending}
+        >
+            {pending ? pendingText : children}
+        </button>
+    )
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -42,10 +42,7 @@
     to   { transform: translateY(0);      opacity: 1; }
 }
 .flash-banner {
-    @apply fixed top-3 left-1/2 -translate-x-1/2 z-50 text-white rounded-xl px-4 py-2 shadow-lg;
+    @apply fixed top-3 left-1/2 -translate-x-1/2 z-50 text-slate-900 rounded-xl px-4 py-2 shadow-lg;
     animation: slideDown 200ms ease-out;
 }
-.flash-success { @apply bg-emerald-500 shadow; }
-.flash-warn    { @apply bg-amber-500 shadow; }
-.flash-error   { @apply bg-rose-500 shadow; }
 


### PR DESCRIPTION
## Summary
- style chore card with gradient border, dark background, and accent text
- swap generic button for glowing gradient submit button
- update flash banner colors to use gradient palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration interaction)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ecd31e8832895c0786c8a1ce207