### PR TITLE
Split Supabase server and action clients

### DIFF
--- a/choreapp/app/kid/actions.ts
+++ b/choreapp/app/kid/actions.ts
@@ -1,9 +1,9 @@
 'use server'
-import { supabaseServer } from '@/lib/supabase/server'
+import { supabaseServerAction } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 
 export async function completeAssignment(assignmentId: string) {
-    const sb = supabaseServer()
+    const sb = supabaseServerAction()
     const { data: { user }, error: ue } = await sb.auth.getUser()
     if (ue) throw ue
     if (!user) throw new Error('Not signed in')
@@ -21,7 +21,7 @@ export async function completeAssignment(assignmentId: string) {
 
 // Form-friendly action that redirects with a flash banner
 export async function completeAssignmentAction(assignmentId: string) {
-    const sb = supabaseServer()
+    const sb = supabaseServerAction()
     const { data: { user } } = await sb.auth.getUser()
     if (!user) redirect('/login')
 

--- a/choreapp/app/parent/actions.ts
+++ b/choreapp/app/parent/actions.ts
@@ -1,9 +1,9 @@
 'use server'
-import { supabaseServer } from '@/lib/supabase/server'
+import { supabaseServerAction } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 
 export async function upsertChore(formData: FormData) {
-    const sb = supabaseServer()
+    const sb = supabaseServerAction()
     const title = String(formData.get('title') || '')
     const amount = Number(formData.get('amount') || 0)
     const householdId = String(formData.get('household_id'))
@@ -14,7 +14,7 @@ export async function upsertChore(formData: FormData) {
 }
 
 export async function createAssignment(formData: FormData) {
-    const sb = supabaseServer()
+    const sb = supabaseServerAction()
     const choreId = String(formData.get('chore_id'))
     const kidId = String(formData.get('kid_id') || '') || null
     const amountOverride = formData.get('amount_override') ? Number(formData.get('amount_override')) : null
@@ -27,14 +27,14 @@ export async function createAssignment(formData: FormData) {
 }
 
 export async function verifyCheckin(id: string) {
-    const sb = supabaseServer()
+    const sb = supabaseServerAction()
     const { error } = await sb.from('checkins').update({ verified: true }).eq('id', id)
     if (error) redirect('/parent?flash=' + encodeURIComponent('Failed to verify') + '&t=error')
     redirect('/parent?flash=' + encodeURIComponent('Check-in verified') + '&t=success')
 }
 
 export async function payKid(householdId: string, kidId: string) {
-    const sb = supabaseServer()
+    const sb = supabaseServerAction()
     const { error } = await sb.rpc('create_full_payout_for_kid', { hh: householdId, kid: kidId })
     const base = '/parent/earnings'
     if (error) redirect(base + '?flash=' + encodeURIComponent('Payout failed') + '&t=error')

--- a/choreapp/lib/supabase/server.ts
+++ b/choreapp/lib/supabase/server.ts
@@ -1,6 +1,11 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+/**
+ * Read-only Supabase client for Server Components. This variant only exposes
+ * `get` so that it cannot modify cookies when invoked outside of a Server
+ * Action or Route Handler.
+ */
 export function supabaseServer() {
   const cookieStore = cookies()
   return createServerClient(
@@ -9,8 +14,27 @@ export function supabaseServer() {
     {
       cookies: {
         get: (name: string) => cookieStore.get(name)?.value,
-        set: (name: string, value: string, options: CookieOptions) => cookieStore.set({ name, value, ...options }),
-        remove: (name: string, options: CookieOptions) => cookieStore.set({ name, value: '', ...options }),
+      },
+    }
+  )
+}
+
+/**
+ * Full Supabase client for use in Server Actions or Route Handlers where
+ * mutating cookies is allowed.
+ */
+export function supabaseServerAction() {
+  const cookieStore = cookies()
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => cookieStore.get(name)?.value,
+        set: (name: string, value: string, options: CookieOptions) =>
+          cookieStore.set({ name, value, ...options }),
+        remove: (name: string, options: CookieOptions) =>
+          cookieStore.set({ name, value: '', ...options }),
       },
     }
   )


### PR DESCRIPTION
## Summary
- break out read-only Supabase server client for server components
- add cookie-capable Supabase client for server actions
- update action modules to use new server action client

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts to configure ESLint)


------
https://chatgpt.com/codex/tasks/task_e_68b8ca63cf7c83289eec1cb3c987ff6d