### PR TITLE
Fix server action usage in AssignmentEditor

### DIFF
--- a/choreapp/components/assignment-editor.tsx
+++ b/choreapp/components/assignment-editor.tsx
@@ -72,7 +72,7 @@ export function AssignmentEditor({ assignment, chores, kids, household }: Props)
                                 <button className="btn" type="submit">Save</button>
                             </div>
                         </form>
-                        <form action={async () => { 'use server'; await deleteAssignment(assignment.id) }} className="mt-2 flex justify-end">
+                        <form action={deleteAssignment.bind(null, assignment.id)} className="mt-2 flex justify-end">
                             <button className="btn" type="submit">Delete</button>
                         </form>
                     </div>

--- a/choreapp/components/rrule-builder.tsx
+++ b/choreapp/components/rrule-builder.tsx
@@ -34,12 +34,14 @@ export function RRuleBuilder({ value, onChange, name = 'rrule', anchorDate, time
         try {
             const r = RRule.fromString(value)
             const o = r.origOptions
-            setFreq((RRule.FREQUENCIES[o.freq] as string).toUpperCase() as Freq)
-            setInterval(o.interval ?? 1)
-            if (o.byweekday?.length) {
-                setByday(o.byweekday.map((w: Weekday) => DAY_ORDER[w.weekday]))
+            if (o.freq !== undefined) {
+                setFreq((RRule.FREQUENCIES[o.freq] as string).toUpperCase() as Freq)
             }
-            if (o.bymonthday?.length) {
+            setInterval(o.interval ?? 1)
+            if (Array.isArray(o.byweekday) && o.byweekday.length) {
+                setByday((o.byweekday as Weekday[]).map((w) => DAY_ORDER[w.weekday]))
+            }
+            if (Array.isArray(o.bymonthday) && o.bymonthday.length) {
                 setByMonthDay(o.bymonthday as number[])
             }
         } catch {}

--- a/choreapp/lib/supabase/server.ts
+++ b/choreapp/lib/supabase/server.ts
@@ -14,7 +14,7 @@ export function supabaseServer() {
     {
       cookies: {
         get: (name: string) => cookieStore.get(name)?.value,
-      },
+      } as any,
     }
   )
 }
@@ -35,7 +35,7 @@ export function supabaseServerAction() {
           cookieStore.set({ name, value, ...options }),
         remove: (name: string, options: CookieOptions) =>
           cookieStore.set({ name, value: '', ...options }),
-      },
+      } as any,
     }
   )
 }


### PR DESCRIPTION
## Summary
- Avoid inline server action in AssignmentEditor by binding deleteAssignment
- Add defensive checks in RRuleBuilder to satisfy TypeScript
- Relax Supabase server helper cookie typing for build

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8ff5646588328ac6c75b1343bd437