### PR TITLE
Organize kid chores by timing

### DIFF
--- a/src/app/kid/page.tsx
+++ b/src/app/kid/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { claimChoreAction, submitChoreAction } from "@/app/kid/actions";
 import { SignOutButton } from "@/components/sign-out-button";
+import { buildDateGroupedSections } from "@/domain/kid-home";
 import { requireCurrentProfile } from "@/lib/auth/session";
 import type { Database } from "@/lib/supabase/database.types";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -11,6 +12,10 @@ type ChoreInstance = Database["public"]["Tables"]["chore_instances"]["Row"];
 type ChoreTemplate = Pick<
   Database["public"]["Tables"]["chore_templates"]["Row"],
   "id" | "title" | "description"
+>;
+type Household = Pick<
+  Database["public"]["Tables"]["households"]["Row"],
+  "id" | "name" | "money_features_enabled"
 >;
 
 function formatMoney(cents: number) {
@@ -51,6 +56,97 @@ function dueLabel(instance: ChoreInstance) {
   return `Due ${instance.occurrence_date}`;
 }
 
+function currentDateString() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function ChoreSubmitCard({
+  household,
+  instance,
+  moneyFeaturesEnabled,
+  template,
+}: {
+  household?: Household;
+  instance: ChoreInstance;
+  moneyFeaturesEnabled: boolean;
+  template?: ChoreTemplate;
+}) {
+  return (
+    <article className="grid gap-4 rounded-lg border border-[var(--line)] bg-[var(--surface)] p-4">
+      <div className="grid gap-1">
+        <h3 className="text-xl font-semibold leading-snug">{template?.title ?? "Chore"}</h3>
+        {template?.description ? (
+          <p className="text-base text-[var(--muted)]">{template.description}</p>
+        ) : null}
+        <p className="text-base text-[var(--muted)]">{dueLabel(instance)}</p>
+        {household ? <p className="text-base text-[var(--muted)]">{household.name}</p> : null}
+      </div>
+      <div className="flex flex-wrap gap-2 text-base font-semibold">
+        <span>{statusLabel(instance)}</span>
+        {moneyFeaturesEnabled && instance.value_model_snapshot === "fixed" ? (
+          <span>{formatMoney(instance.amount_cents_snapshot)}</span>
+        ) : null}
+        {instance.photo_required_snapshot ? <span>Photo required</span> : null}
+      </div>
+      <form action={submitChoreAction} className="grid gap-3">
+        <input name="instanceId" type="hidden" value={instance.id} />
+        <label className="grid gap-2 text-base font-semibold">
+          Note
+          <textarea
+            className="min-h-24 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg"
+            maxLength={500}
+            name="note"
+          />
+        </label>
+        {instance.photo_required_snapshot ? (
+          <label className="grid gap-2 text-base font-semibold">
+            Photo proof
+            <input
+              className="min-h-12 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg"
+              name="photoStoragePath"
+              placeholder="Photo proof placeholder"
+              required
+              type="text"
+            />
+          </label>
+        ) : null}
+        <button className="min-h-12 rounded-lg bg-[var(--accent)] px-4 py-3 text-lg font-semibold text-white">
+          Submit
+        </button>
+      </form>
+    </article>
+  );
+}
+
+function ChoreClaimCard({
+  household,
+  instance,
+  template,
+}: {
+  household?: Household;
+  instance: ChoreInstance;
+  template?: ChoreTemplate;
+}) {
+  return (
+    <article className="grid gap-3 rounded-lg border border-[var(--line)] bg-[var(--surface)] p-4">
+      <div className="grid gap-1">
+        <h3 className="text-xl font-semibold leading-snug">{template?.title ?? "Chore"}</h3>
+        {template?.description ? (
+          <p className="text-base text-[var(--muted)]">{template.description}</p>
+        ) : null}
+        <p className="text-base text-[var(--muted)]">{dueLabel(instance)}</p>
+        {household ? <p className="text-base text-[var(--muted)]">{household.name}</p> : null}
+      </div>
+      <form action={claimChoreAction}>
+        <input name="instanceId" type="hidden" value={instance.id} />
+        <button className="min-h-12 rounded-lg bg-[var(--accent)] px-4 py-3 text-lg font-semibold text-white">
+          Claim
+        </button>
+      </form>
+    </article>
+  );
+}
+
 export default async function KidHomePage({
   searchParams,
 }: {
@@ -81,7 +177,7 @@ export default async function KidHomePage({
 
   const householdIds = memberships?.map((membership) => membership.household_id) ?? [];
   const { data: households, error: householdError } = householdIds.length
-    ? await supabase.from("households").select("id, money_features_enabled").in("id", householdIds)
+    ? await supabase.from("households").select("id, name, money_features_enabled").in("id", householdIds)
     : { data: [], error: null };
 
   if (householdError) {
@@ -123,9 +219,13 @@ export default async function KidHomePage({
   const templateById = new Map<string, ChoreTemplate>(
     templates?.map((template) => [template.id, template]) ?? [],
   );
+  const householdById = new Map<string, Household>(
+    households?.map((household) => [household.id, household]) ?? [],
+  );
   const toDoChores =
     instances?.filter((instance) => instance.status === "assigned" || instance.status === "rejected") ??
     [];
+  const toDoSections = buildDateGroupedSections(toDoChores, currentDateString());
   const waitingChores = instances?.filter((instance) => instance.status === "submitted") ?? [];
   const availableChores = instances?.filter((instance) => instance.status === "available") ?? [];
   const { data: ledgerRows, error: ledgerError } = childProfile && moneyFeaturesEnabled
@@ -219,72 +319,40 @@ export default async function KidHomePage({
           </section>
         ) : null}
 
-        <section aria-labelledby="today-heading" className="grid gap-3">
-          <h2 id="today-heading" className="text-xl font-semibold">
-            To do
-          </h2>
-          <div className="grid gap-3">
-            {toDoChores.length ? (
-              toDoChores.map((instance) => {
-                const template = templateById.get(instance.template_id);
-
-                return (
-                  <article
-                    className="grid gap-4 rounded-lg border border-[var(--line)] bg-[var(--surface)] p-4"
-                    key={instance.id}
-                  >
-                    <div className="grid gap-1">
-                      <h3 className="text-xl font-semibold leading-snug">
-                        {template?.title ?? "Chore"}
-                      </h3>
-                      {template?.description ? (
-                        <p className="text-base text-[var(--muted)]">{template.description}</p>
-                      ) : null}
-                      <p className="text-base text-[var(--muted)]">{dueLabel(instance)}</p>
-                    </div>
-                    <div className="flex flex-wrap gap-2 text-base font-semibold">
-                      <span>{statusLabel(instance)}</span>
-                      {moneyFeaturesEnabled && instance.value_model_snapshot === "fixed" ? (
-                        <span>{formatMoney(instance.amount_cents_snapshot)}</span>
-                      ) : null}
-                      {instance.photo_required_snapshot ? <span>Photo required</span> : null}
-                    </div>
-                    <form action={submitChoreAction} className="grid gap-3">
-                      <input name="instanceId" type="hidden" value={instance.id} />
-                      <label className="grid gap-2 text-base font-semibold">
-                        Note
-                        <textarea
-                          className="min-h-24 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg"
-                          maxLength={500}
-                          name="note"
-                        />
-                      </label>
-                      {instance.photo_required_snapshot ? (
-                        <label className="grid gap-2 text-base font-semibold">
-                          Photo proof
-                          <input
-                            className="min-h-12 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg"
-                            name="photoStoragePath"
-                            placeholder="Photo proof placeholder"
-                            required
-                            type="text"
-                          />
-                        </label>
-                      ) : null}
-                      <button className="min-h-12 rounded-lg bg-[var(--accent)] px-4 py-3 text-lg font-semibold text-white">
-                        Submit
-                      </button>
-                    </form>
-                  </article>
-                );
-              })
-            ) : (
-              <p className="rounded-lg border border-[var(--line)] bg-white p-4 text-lg text-[var(--muted)]">
-                No chores are ready to submit.
-              </p>
-            )}
-          </div>
-        </section>
+        {toDoChores.length ? (
+          toDoSections.map((section) =>
+            section.items.length ? (
+              <section aria-labelledby={`${section.id}-heading`} className="grid gap-3" key={section.id}>
+                <div className="grid gap-1">
+                  <h2 id={`${section.id}-heading`} className="text-xl font-semibold">
+                    {section.title}
+                  </h2>
+                  <p className="text-base text-[var(--muted)]">{section.description}</p>
+                </div>
+                <div className="grid gap-3">
+                  {section.items.map((instance) => (
+                    <ChoreSubmitCard
+                      household={householdById.get(instance.earning_household_id)}
+                      instance={instance}
+                      key={instance.id}
+                      moneyFeaturesEnabled={moneyFeaturesEnabled}
+                      template={templateById.get(instance.template_id)}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null,
+          )
+        ) : (
+          <section aria-labelledby="today-heading" className="grid gap-3">
+            <h2 id="today-heading" className="text-xl font-semibold">
+              Today
+            </h2>
+            <p className="rounded-lg border border-[var(--line)] bg-white p-4 text-lg text-[var(--muted)]">
+              No chores are ready to submit.
+            </p>
+          </section>
+        )}
 
         {availableChores.length ? (
           <section aria-labelledby="available-heading" className="grid gap-3">
@@ -296,26 +364,12 @@ export default async function KidHomePage({
                 const template = templateById.get(instance.template_id);
 
                 return (
-                  <article
-                    className="grid gap-3 rounded-lg border border-[var(--line)] bg-[var(--surface)] p-4"
+                  <ChoreClaimCard
+                    household={householdById.get(instance.earning_household_id)}
+                    instance={instance}
                     key={instance.id}
-                  >
-                    <div className="grid gap-1">
-                      <h3 className="text-xl font-semibold leading-snug">
-                        {template?.title ?? "Chore"}
-                      </h3>
-                      {template?.description ? (
-                        <p className="text-base text-[var(--muted)]">{template.description}</p>
-                      ) : null}
-                      <p className="text-base text-[var(--muted)]">{dueLabel(instance)}</p>
-                    </div>
-                    <form action={claimChoreAction}>
-                      <input name="instanceId" type="hidden" value={instance.id} />
-                      <button className="min-h-12 rounded-lg bg-[var(--accent)] px-4 py-3 text-lg font-semibold text-white">
-                        Claim
-                      </button>
-                    </form>
-                  </article>
+                    template={template}
+                  />
                 );
               })}
             </div>
@@ -340,6 +394,11 @@ export default async function KidHomePage({
                       {template?.title ?? "Chore"}
                     </h3>
                     <p className="text-lg font-medium">{statusLabel(instance)}</p>
+                    {householdById.get(instance.earning_household_id) ? (
+                      <p className="text-base text-[var(--muted)]">
+                        {householdById.get(instance.earning_household_id)?.name}
+                      </p>
+                    ) : null}
                   </article>
                 );
               })}

--- a/src/domain/kid-home.test.ts
+++ b/src/domain/kid-home.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildDateGroupedSections } from "./kid-home";
+
+describe("buildDateGroupedSections", () => {
+  it("groups overdue and current items into Today", () => {
+    const sections = buildDateGroupedSections(
+      [
+        { id: "overdue", occurrence_date: "2026-05-26" },
+        { id: "today", occurrence_date: "2026-05-27" },
+      ],
+      "2026-05-27",
+    );
+
+    expect(sections[0].items.map((item) => item.id)).toEqual(["overdue", "today"]);
+  });
+
+  it("groups items due within seven days into This week", () => {
+    const sections = buildDateGroupedSections(
+      [
+        { id: "tomorrow", occurrence_date: "2026-05-28" },
+        { id: "week-end", occurrence_date: "2026-06-03" },
+      ],
+      "2026-05-27",
+    );
+
+    expect(sections[1].items.map((item) => item.id)).toEqual(["tomorrow", "week-end"]);
+  });
+
+  it("groups later items into Whenever", () => {
+    const sections = buildDateGroupedSections(
+      [{ id: "later", occurrence_date: "2026-06-04" }],
+      "2026-05-27",
+    );
+
+    expect(sections[2].items.map((item) => item.id)).toEqual(["later"]);
+  });
+});

--- a/src/domain/kid-home.ts
+++ b/src/domain/kid-home.ts
@@ -1,0 +1,50 @@
+export type DateGroupedItem = {
+  occurrence_date: string;
+};
+
+export type DateGroupedSection<TItem extends DateGroupedItem> = {
+  items: TItem[];
+  description: string;
+  id: string;
+  title: string;
+};
+
+export function addDays(date: string, days: number) {
+  const next = new Date(`${date}T00:00:00.000Z`);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next.toISOString().slice(0, 10);
+}
+
+export function buildDateGroupedSections<TItem extends DateGroupedItem>(
+  items: TItem[],
+  today: string,
+): DateGroupedSection<TItem>[] {
+  const weekEnd = addDays(today, 7);
+
+  const todayItems = items.filter((item) => item.occurrence_date <= today);
+  const weekItems = items.filter(
+    (item) => item.occurrence_date > today && item.occurrence_date <= weekEnd,
+  );
+  const wheneverItems = items.filter((item) => item.occurrence_date > weekEnd);
+
+  return [
+    {
+      items: todayItems,
+      description: "Ready now or already due.",
+      id: "today",
+      title: "Today",
+    },
+    {
+      items: weekItems,
+      description: "Coming up in the next week.",
+      id: "week",
+      title: "This week",
+    },
+    {
+      items: wheneverItems,
+      description: "Not urgent yet.",
+      id: "whenever",
+      title: "Whenever",
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- organize kid assigned/rejected chores into Today, This week, and Whenever sections
- show household names on kid chore cards for split-household clarity
- extract and test the date grouping rule

## Verification
- npm run typecheck
- npm test
- local /kid route smoke check returned expected auth redirect