### PR TITLE
[codex] Add chore photo proof upload and review

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -217,7 +217,7 @@ Add notable bugs here as they are found. Each entry should include the bug, the 
 
 ## 9) UI polish backlog
 
-- Add show/hide password controls to sign-in and sign-up password fields.
+- None yet.
 
 ## 10) Current local SQL smoke tests
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,11 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "6mb",
+    },
+  },
+};
 
 export default nextConfig;

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { signInAction } from "@/app/auth/actions";
+import { PasswordField } from "@/components/password-field";
 
 export default async function SignInPage({
   searchParams,
@@ -39,16 +40,7 @@ export default async function SignInPage({
             />
           </label>
 
-          <label className="grid gap-2 text-lg font-semibold">
-            Password
-            <input
-              autoComplete="current-password"
-              className="min-h-12 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg"
-              name="password"
-              required
-              type="password"
-            />
-          </label>
+          <PasswordField autoComplete="current-password" label="Password" name="password" />
 
           <button className="min-h-12 rounded-lg bg-[var(--accent)] px-5 py-3 text-lg font-semibold text-white">
             Sign in

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { signUpAction } from "@/app/auth/actions";
+import { PasswordField } from "@/components/password-field";
 
 export default async function SignUpPage({
   searchParams,
@@ -50,17 +51,12 @@ export default async function SignUpPage({
             />
           </label>
 
-          <label className="grid gap-2 text-lg font-semibold">
-            Password
-            <input
-              autoComplete="new-password"
-              className="min-h-12 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg"
-              minLength={8}
-              name="password"
-              required
-              type="password"
-            />
-          </label>
+          <PasswordField
+            autoComplete="new-password"
+            label="Password"
+            minLength={8}
+            name="password"
+          />
 
           <fieldset className="grid gap-3">
             <legend className="text-lg font-semibold">Account type</legend>

--- a/src/app/kid/actions.ts
+++ b/src/app/kid/actions.ts
@@ -3,7 +3,18 @@
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import { claimChoreInstance, submitChoreInstance } from "@/lib/supabase/chore-commands";
+import { requireCurrentProfile } from "@/lib/auth/session";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const PHOTO_BUCKET = "chore-submission-photos";
+const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
+const PHOTO_EXTENSIONS = new Map([
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/webp", "webp"],
+  ["image/heic", "heic"],
+  ["image/heif", "heif"],
+]);
 
 const instanceSchema = z.object({
   instanceId: z.uuid(),
@@ -11,7 +22,6 @@ const instanceSchema = z.object({
 
 const submitChoreSchema = instanceSchema.extend({
   note: z.string().trim().max(500).optional(),
-  photoStoragePath: z.string().trim().max(240).optional(),
 });
 
 function kidError(message: string): never {
@@ -21,6 +31,27 @@ function kidError(message: string): never {
 function optionalString(value: FormDataEntryValue | null) {
   const stringValue = String(value ?? "").trim();
   return stringValue.length ? stringValue : undefined;
+}
+
+function optionalFile(value: FormDataEntryValue | null) {
+  return value instanceof File && value.size > 0 ? value : undefined;
+}
+
+function photoValidationError(file: File) {
+  if (file.size > MAX_PHOTO_BYTES) {
+    return "Photo proof must be 5 MB or smaller.";
+  }
+
+  if (!PHOTO_EXTENSIONS.has(file.type)) {
+    return "Photo proof must be a JPEG, PNG, WebP, HEIC, or HEIF image.";
+  }
+
+  return null;
+}
+
+function photoStoragePath(profileId: string, instanceId: string, file: File) {
+  const extension = PHOTO_EXTENSIONS.get(file.type) ?? "jpg";
+  return `${profileId}/${instanceId}/${crypto.randomUUID()}.${extension}`;
 }
 
 export async function claimChoreAction(formData: FormData) {
@@ -45,24 +76,83 @@ export async function claimChoreAction(formData: FormData) {
 }
 
 export async function submitChoreAction(formData: FormData) {
+  const photo = optionalFile(formData.get("photo"));
   const parsed = submitChoreSchema.safeParse({
     instanceId: formData.get("instanceId"),
     note: optionalString(formData.get("note")),
-    photoStoragePath: optionalString(formData.get("photoStoragePath")),
   });
 
   if (!parsed.success) {
     kidError("Check the submission and try again.");
   }
 
+  const validationError = photo ? photoValidationError(photo) : null;
+
+  if (validationError) {
+    kidError(validationError);
+  }
+
+  const profile = await requireCurrentProfile();
   const supabase = await createSupabaseServerClient();
+  const { data: childProfile, error: childProfileError } = await supabase
+    .from("child_profiles")
+    .select("id")
+    .eq("user_id", profile.id)
+    .maybeSingle();
+
+  if (childProfileError) {
+    throw new Error(childProfileError.message);
+  }
+
+  if (!childProfile) {
+    kidError("Child profile is required to submit chores.");
+  }
+
+  const { data: instance, error: instanceError } = await supabase
+    .from("chore_instances")
+    .select("assigned_child_profile_id, photo_required_snapshot, status")
+    .eq("id", parsed.data.instanceId)
+    .maybeSingle();
+
+  if (instanceError) {
+    throw new Error(instanceError.message);
+  }
+
+  if (!instance || instance.assigned_child_profile_id !== childProfile.id) {
+    kidError("That chore is not assigned to this child.");
+  }
+
+  if (instance.status !== "assigned" && instance.status !== "rejected") {
+    kidError("That chore is not ready to submit.");
+  }
+
+  if (instance.photo_required_snapshot && !photo) {
+    kidError("Add photo proof before submitting this chore.");
+  }
+
+  let uploadedPhotoPath: string | null = null;
+
+  if (photo) {
+    uploadedPhotoPath = photoStoragePath(profile.id, parsed.data.instanceId, photo);
+    const { error: uploadError } = await supabase.storage
+      .from(PHOTO_BUCKET)
+      .upload(uploadedPhotoPath, photo, {
+        contentType: photo.type,
+        upsert: false,
+      });
+
+    if (uploadError) {
+      kidError(uploadError.message);
+    }
+  }
+
   let submissionId: string;
 
   try {
     submissionId = await submitChoreInstance(supabase, {
       instanceId: parsed.data.instanceId,
       note: parsed.data.note ?? null,
-      photoStoragePath: parsed.data.photoStoragePath ?? null,
+      photoStoragePath: uploadedPhotoPath,
     });
   } catch (error) {
     kidError(error instanceof Error ? error.message : "Could not submit chore.");

--- a/src/app/kid/page.tsx
+++ b/src/app/kid/page.tsx
@@ -88,7 +88,7 @@ function ChoreSubmitCard({
         ) : null}
         {instance.photo_required_snapshot ? <span>Photo required</span> : null}
       </div>
-      <form action={submitChoreAction} className="grid gap-3">
+      <form action={submitChoreAction} className="grid gap-3" encType="multipart/form-data">
         <input name="instanceId" type="hidden" value={instance.id} />
         <label className="grid gap-2 text-base font-semibold">
           Note
@@ -102,11 +102,11 @@ function ChoreSubmitCard({
           <label className="grid gap-2 text-base font-semibold">
             Photo proof
             <input
-              className="min-h-12 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg"
-              name="photoStoragePath"
-              placeholder="Photo proof placeholder"
+              accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+              className="min-h-12 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg file:mr-4 file:rounded-md file:border-0 file:bg-[var(--background)] file:px-3 file:py-2 file:text-base file:font-semibold file:text-[var(--accent-strong)]"
+              name="photo"
               required
-              type="text"
+              type="file"
             />
           </label>
         ) : null}

--- a/src/app/parent/actions.ts
+++ b/src/app/parent/actions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import {
   approveChoreSubmissionForCurrentPeriod,
   closeOutPayout,
+  deleteSubmissionPhoto,
   rejectChoreSubmission,
 } from "@/lib/supabase/chore-commands";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -23,6 +24,10 @@ const closeOutPayoutSchema = z.object({
   childProfileId: z.uuid(),
   payPeriodId: z.uuid(),
   note: z.string().trim().max(500).optional(),
+});
+
+const deleteSubmissionPhotoSchema = z.object({
+  submissionId: z.uuid(),
 });
 
 function parentDashboardError(message: string): never {
@@ -109,4 +114,24 @@ export async function closeOutPayoutAction(formData: FormData) {
   }
 
   redirect(`/parent?paid=${payoutId}`);
+}
+
+export async function deleteSubmissionPhotoAction(formData: FormData) {
+  const parsed = deleteSubmissionPhotoSchema.safeParse({
+    submissionId: formData.get("submissionId"),
+  });
+
+  if (!parsed.success) {
+    parentDashboardError("That photo could not be removed.");
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  try {
+    await deleteSubmissionPhoto(supabase, parsed.data.submissionId);
+  } catch (error) {
+    parentDashboardError(error instanceof Error ? error.message : "Could not remove photo.");
+  }
+
+  redirect("/parent?photoDeleted=1");
 }

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import {
   approveSubmissionAction,
   closeOutPayoutAction,
+  deleteSubmissionPhotoAction,
   rejectSubmissionAction,
 } from "@/app/parent/actions";
 import { ParentNav } from "@/components/parent-nav";
@@ -19,6 +20,7 @@ export default async function ParentHomePage({
     createdChore?: string;
     error?: string;
     paid?: string;
+    photoDeleted?: string;
     rejected?: string;
   }>;
 }) {
@@ -151,7 +153,9 @@ export default async function ParentHomePage({
   const { data: submissions, error: submissionError } = submittedInstanceIds.length
     ? await supabase
         .from("chore_submissions")
-        .select("id, instance_id, note, photo_storage_path, attempt_number, submitted_at")
+        .select(
+          "id, instance_id, note, photo_storage_path, photo_deleted_at, attempt_number, submitted_at",
+        )
         .in("instance_id", submittedInstanceIds)
         .order("attempt_number", { ascending: false })
     : { data: [], error: null };
@@ -161,7 +165,30 @@ export default async function ParentHomePage({
   }
 
   const latestSubmissionByInstanceId = new Map(
-    submissions?.map((submission) => [submission.instance_id, submission]) ?? [],
+    submissions?.reduce<Array<[string, (typeof submissions)[number]]>>((rows, submission) => {
+      if (!rows.some(([instanceId]) => instanceId === submission.instance_id)) {
+        rows.push([submission.instance_id, submission]);
+      }
+
+      return rows;
+    }, []) ?? [],
+  );
+  const photoSubmissions =
+    submissions?.filter(
+      (submission) => submission.photo_storage_path && !submission.photo_deleted_at,
+    ) ?? [];
+  const signedPhotoUrlBySubmissionId = new Map(
+    (
+      await Promise.all(
+        photoSubmissions.map(async (submission) => {
+          const { data } = await supabase.storage
+            .from("chore-submission-photos")
+            .createSignedUrl(submission.photo_storage_path ?? "", 600);
+
+          return data?.signedUrl ? ([submission.id, data.signedUrl] as const) : null;
+        }),
+      )
+    ).filter((row): row is readonly [string, string] => row !== null),
   );
   const { data: approvedLedger, error: approvedLedgerError } = childProfiles.length && moneyFeaturesEnabled
     ? await supabase
@@ -283,6 +310,12 @@ export default async function ParentHomePage({
           </p>
         ) : null}
 
+        {params.photoDeleted ? (
+          <p className="rounded-lg border border-[var(--line)] bg-white p-4 text-lg font-medium">
+            Photo removed.
+          </p>
+        ) : null}
+
         {hasChildren ? (
           <>
             {moneyFeaturesEnabled ? (
@@ -378,10 +411,35 @@ export default async function ParentHomePage({
                             {submission?.note ? (
                               <p className="text-base">{submission.note}</p>
                             ) : null}
-                            {submission?.photo_storage_path ? (
-                              <p className="break-all text-base text-[var(--muted)]">
-                                Photo: {submission.photo_storage_path}
-                              </p>
+                            {submission?.photo_storage_path && !submission.photo_deleted_at ? (
+                              <div className="grid gap-3">
+                                {signedPhotoUrlBySubmissionId.get(submission.id) ? (
+                                  <a
+                                    className="block overflow-hidden rounded-lg border border-[var(--line)] bg-white"
+                                    href={signedPhotoUrlBySubmissionId.get(submission.id)}
+                                    rel="noreferrer"
+                                    target="_blank"
+                                  >
+                                    <img
+                                      alt={`Photo proof for ${
+                                        templateTitleById.get(instance.template_id) ?? "chore"
+                                      }`}
+                                      className="max-h-80 w-full object-contain"
+                                      src={signedPhotoUrlBySubmissionId.get(submission.id)}
+                                    />
+                                  </a>
+                                ) : (
+                                  <p className="rounded-lg border border-[var(--line)] bg-white p-3 text-base text-[var(--muted)]">
+                                    Photo proof could not be loaded.
+                                  </p>
+                                )}
+                                <form action={deleteSubmissionPhotoAction}>
+                                  <input name="submissionId" type="hidden" value={submission.id} />
+                                  <button className="min-h-11 rounded-lg border border-[var(--line)] bg-white px-4 py-2 text-base font-semibold text-[var(--danger)]">
+                                    Remove photo
+                                  </button>
+                                </form>
+                              </div>
                             ) : null}
                           </div>
 

--- a/src/components/password-field.tsx
+++ b/src/components/password-field.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useId, useState } from "react";
+
+type PasswordFieldProps = {
+  autoComplete: string;
+  label: string;
+  minLength?: number;
+  name: string;
+};
+
+export function PasswordField({ autoComplete, label, minLength, name }: PasswordFieldProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const inputId = useId();
+
+  return (
+    <div className="grid gap-2 text-lg font-semibold">
+      <label htmlFor={inputId}>{label}</label>
+      <div className="grid gap-2 sm:flex sm:items-stretch">
+        <input
+          autoComplete={autoComplete}
+          className="min-h-12 min-w-0 flex-1 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg"
+          id={inputId}
+          minLength={minLength}
+          name={name}
+          required
+          type={isVisible ? "text" : "password"}
+        />
+        <button
+          aria-controls={inputId}
+          aria-pressed={isVisible}
+          className="min-h-12 rounded-lg border border-[var(--line)] bg-white px-4 py-3 text-lg font-semibold text-[var(--accent-strong)]"
+          onClick={() => setIsVisible((current) => !current)}
+          type="button"
+        >
+          {isVisible ? "Hide" : "Show"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/202605270001_chore_submission_photo_storage.sql
+++ b/supabase/migrations/202605270001_chore_submission_photo_storage.sql
@@ -1,0 +1,52 @@
+-- Storage bucket and access policies for chore submission photo evidence.
+
+insert into storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types
+)
+values (
+  'chore-submission-photos',
+  'chore-submission-photos',
+  false,
+  5242880,
+  array['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif']
+)
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+create policy "Children can upload own chore submission photos"
+on storage.objects for insert
+with check (
+  bucket_id = 'chore-submission-photos'
+  and auth.uid() is not null
+  and name like auth.uid()::text || '/%'
+);
+
+create policy "Photo owners can read own chore submission photos"
+on storage.objects for select
+using (
+  bucket_id = 'chore-submission-photos'
+  and auth.uid() is not null
+  and name like auth.uid()::text || '/%'
+);
+
+create policy "Household members can read submitted chore photos"
+on storage.objects for select
+using (
+  bucket_id = 'chore-submission-photos'
+  and exists (
+    select 1
+    from public.chore_submissions submission
+    join public.chore_instances instance
+      on instance.id = submission.instance_id
+    where submission.photo_storage_path = storage.objects.name
+      and submission.photo_deleted_at is null
+      and public.is_household_member(instance.earning_household_id)
+  )
+);

--- a/supabase/tests/kid_chore_flow_smoke.sql
+++ b/supabase/tests/kid_chore_flow_smoke.sql
@@ -5,8 +5,10 @@ do $$
 declare
   parent_id uuid := '00000000-0000-4000-8000-000000000701';
   child_id uuid := '00000000-0000-4000-8000-000000000702';
+  other_child_id uuid := '00000000-0000-4000-8000-000000000703';
   target_household_id uuid;
   target_child_profile_id uuid;
+  other_child_profile_id uuid;
   selected_template_id uuid;
   up_for_grabs_template_id uuid;
   selected_instance_id uuid;
@@ -14,6 +16,8 @@ declare
   claim_id uuid;
   selected_submission_id uuid;
   claimed_submission_id uuid;
+  second_claim_rejected boolean := false;
+  wrong_child_submit_rejected boolean := false;
 begin
   insert into auth.users (id, email, raw_user_meta_data, is_sso_user, is_anonymous)
   values
@@ -30,6 +34,13 @@ begin
       jsonb_build_object('app_role', 'child', 'display_name', 'Kid Flow Child'),
       false,
       false
+    ),
+    (
+      other_child_id,
+      'kid-flow-other-child@example.test',
+      jsonb_build_object('app_role', 'child', 'display_name', 'Other Kid Flow Child'),
+      false,
+      false
     );
 
   insert into public.households (name, created_by)
@@ -39,11 +50,16 @@ begin
   insert into public.household_memberships (household_id, user_id, role, is_primary_payout_parent)
   values
     (target_household_id, parent_id, 'admin', true),
-    (target_household_id, child_id, 'child', false);
+    (target_household_id, child_id, 'child', false),
+    (target_household_id, other_child_id, 'child', false);
 
   insert into public.child_profiles (user_id, primary_household_id, created_by)
   values (child_id, target_household_id, parent_id)
   returning id into target_child_profile_id;
+
+  insert into public.child_profiles (user_id, primary_household_id, created_by)
+  values (other_child_id, target_household_id, parent_id)
+  returning id into other_child_profile_id;
 
   perform set_config('request.jwt.claim.sub', parent_id::text, true);
 
@@ -122,6 +138,45 @@ begin
   ) then
     raise exception 'Expected up-for-grabs chore to become assigned to child';
   end if;
+
+  perform set_config('request.jwt.claim.sub', other_child_id::text, true);
+
+  begin
+    perform public.claim_chore_instance(available_instance_id);
+  exception
+    when others then
+      second_claim_rejected := true;
+  end;
+
+  if not second_claim_rejected then
+    raise exception 'Expected second child claim to be rejected';
+  end if;
+
+  begin
+    perform public.submit_chore_instance(
+      available_instance_id,
+      'Trying to submit another child claim',
+      null
+    );
+  exception
+    when others then
+      wrong_child_submit_rejected := true;
+  end;
+
+  if not wrong_child_submit_rejected then
+    raise exception 'Expected other child submit to be rejected';
+  end if;
+
+  if exists (
+    select 1
+    from public.chore_claims claim
+    where claim.instance_id = available_instance_id
+      and claim.child_profile_id = other_child_profile_id
+  ) then
+    raise exception 'Other child should not have a claim row';
+  end if;
+
+  perform set_config('request.jwt.claim.sub', child_id::text, true);
 
   selected_submission_id := public.submit_chore_instance(
     selected_instance_id,


### PR DESCRIPTION
## Summary

Adds a checkpoint for chore photo proof, parent review, and auth polish:

- Extends the kid chore flow smoke test coverage for up-for-grabs claim ownership.
- Adds reusable password visibility controls to the sign-in and sign-up forms.
- Adds a private Supabase storage bucket and policies for chore submission photos.
- Replaces the kid photo-proof placeholder with a real image upload flow, including file type and size validation.
- Shows signed photo previews in the parent approval queue and lets parents mark submitted photos removed.
- Raises the Server Actions body limit to support the 5 MB photo cap.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run build`
- `supabase db lint`
- `supabase db reset --local --no-seed`
- `psql -f supabase/tests/kid_chore_flow_smoke.sql`
- full SQL smoke suite in `supabase/tests/*.sql`

## Notes

Photo removal currently marks the submission photo as deleted in app history. Physical storage object cleanup remains a follow-up job slice.