### PR TITLE
[codex] Clean up chore photo storage objects

### DIFF
--- a/docs/schema-notes.md
+++ b/docs/schema-notes.md
@@ -196,8 +196,8 @@ The first service-layer commands live as database RPC functions so multi-row sta
 - `approve_chore_submission(submission_id, pay_period_id, approved_on, feedback)` approves a submitted chore and creates the approved-credit ledger row only for fixed-value chores in money-enabled households.
 - `reject_chore_submission(submission_id, feedback)` rejects a submitted chore and preserves parent feedback.
 - `reopen_chore_instance(instance_id, feedback)` moves rejected or expired chores back to assigned and records the reopen event.
-- `delete_submission_photo(submission_id)` lets a household parent mark a submitted photo deleted without deleting submission history.
-- `close_out_payout(pay_period_id, child_profile_id, note)` creates one payout event, appends the payout ledger row, and marks related submission photos deleted after closeout.
+- `delete_submission_photo(submission_id)` lets a household parent mark a submitted photo deleted without deleting submission history; the parent server action also attempts to remove the stored object.
+- `close_out_payout(pay_period_id, child_profile_id, note)` creates one payout event, appends the payout ledger row, and marks related submission photos deleted after closeout; the parent server action also attempts to remove the stored objects.
 
 `create_chore_credit` and `current_payout_parent_id` are internal helper functions used by command RPCs.
 
@@ -300,6 +300,6 @@ Policies are intentionally conservative and should be reviewed before production
 - Add service-layer generation tests that prove all-eligible and up-for-grabs instances respect custody availability and overrides.
 - Add generated TypeScript wrappers for RPC command calls once Supabase client code is introduced.
 - Add pay-period creation/upsert command so approval flows do not require callers to pre-create periods manually.
-- Add object-storage cleanup job for parent-deleted photos and pay-period retention deletion.
+- Add a retryable object-storage cleanup job for photo object removals that fail during parent deletion or pay-period closeout.
 - Expand onboarding for secondary parent invitations.
 - Add hosted email delivery for invitation links once Supabase email settings are configured.

--- a/src/app/kid/actions.ts
+++ b/src/app/kid/actions.ts
@@ -4,17 +4,13 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 import { claimChoreInstance, submitChoreInstance } from "@/lib/supabase/chore-commands";
 import { requireCurrentProfile } from "@/lib/auth/session";
+import {
+  CHORE_SUBMISSION_PHOTO_BUCKET,
+  chorePhotoStoragePath,
+  chorePhotoValidationError,
+  removeStoredChorePhotos,
+} from "@/lib/supabase/chore-photo-storage";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-
-const PHOTO_BUCKET = "chore-submission-photos";
-const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
-const PHOTO_EXTENSIONS = new Map([
-  ["image/jpeg", "jpg"],
-  ["image/png", "png"],
-  ["image/webp", "webp"],
-  ["image/heic", "heic"],
-  ["image/heif", "heif"],
-]);
 
 const instanceSchema = z.object({
   instanceId: z.uuid(),
@@ -35,23 +31,6 @@ function optionalString(value: FormDataEntryValue | null) {
 
 function optionalFile(value: FormDataEntryValue | null) {
   return value instanceof File && value.size > 0 ? value : undefined;
-}
-
-function photoValidationError(file: File) {
-  if (file.size > MAX_PHOTO_BYTES) {
-    return "Photo proof must be 5 MB or smaller.";
-  }
-
-  if (!PHOTO_EXTENSIONS.has(file.type)) {
-    return "Photo proof must be a JPEG, PNG, WebP, HEIC, or HEIF image.";
-  }
-
-  return null;
-}
-
-function photoStoragePath(profileId: string, instanceId: string, file: File) {
-  const extension = PHOTO_EXTENSIONS.get(file.type) ?? "jpg";
-  return `${profileId}/${instanceId}/${crypto.randomUUID()}.${extension}`;
 }
 
 export async function claimChoreAction(formData: FormData) {
@@ -86,7 +65,7 @@ export async function submitChoreAction(formData: FormData) {
     kidError("Check the submission and try again.");
   }
 
-  const validationError = photo ? photoValidationError(photo) : null;
+  const validationError = photo ? chorePhotoValidationError(photo) : null;
 
   if (validationError) {
     kidError(validationError);
@@ -133,9 +112,9 @@ export async function submitChoreAction(formData: FormData) {
   let uploadedPhotoPath: string | null = null;
 
   if (photo) {
-    uploadedPhotoPath = photoStoragePath(profile.id, parsed.data.instanceId, photo);
+    uploadedPhotoPath = chorePhotoStoragePath(profile.id, parsed.data.instanceId, photo);
     const { error: uploadError } = await supabase.storage
-      .from(PHOTO_BUCKET)
+      .from(CHORE_SUBMISSION_PHOTO_BUCKET)
       .upload(uploadedPhotoPath, photo, {
         contentType: photo.type,
         upsert: false,
@@ -155,6 +134,7 @@ export async function submitChoreAction(formData: FormData) {
       photoStoragePath: uploadedPhotoPath,
     });
   } catch (error) {
+    await removeStoredChorePhotos([uploadedPhotoPath]);
     kidError(error instanceof Error ? error.message : "Could not submit chore.");
   }
 

--- a/src/app/parent/actions.ts
+++ b/src/app/parent/actions.ts
@@ -8,6 +8,10 @@ import {
   deleteSubmissionPhoto,
   rejectChoreSubmission,
 } from "@/lib/supabase/chore-commands";
+import {
+  createPhotoCleanupLookupClient,
+  removeStoredChorePhotos,
+} from "@/lib/supabase/chore-photo-storage";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 const approveSubmissionSchema = z.object({
@@ -101,6 +105,38 @@ export async function closeOutPayoutAction(formData: FormData) {
   }
 
   const supabase = await createSupabaseServerClient();
+  const photoLookupSupabase = createPhotoCleanupLookupClient(supabase);
+  const { data: approvedLedgerRows, error: ledgerError } = await photoLookupSupabase
+    .from("ledger_transactions")
+    .select("chore_instance_id")
+    .eq("pay_period_id", parsed.data.payPeriodId)
+    .eq("child_profile_id", parsed.data.childProfileId)
+    .eq("transaction_type", "approved_credit");
+
+  if (ledgerError) {
+    throw new Error(ledgerError.message);
+  }
+
+  const approvedInstanceIds = [
+    ...new Set(
+      approvedLedgerRows
+        ?.map((row) => row.chore_instance_id)
+        .filter((instanceId): instanceId is string => Boolean(instanceId)) ?? [],
+    ),
+  ];
+  const { data: photoSubmissions, error: photoSubmissionError } = approvedInstanceIds.length
+    ? await photoLookupSupabase
+        .from("chore_submissions")
+        .select("photo_storage_path")
+        .in("instance_id", approvedInstanceIds)
+        .is("photo_deleted_at", null)
+        .not("photo_storage_path", "is", null)
+    : { data: [], error: null };
+
+  if (photoSubmissionError) {
+    throw new Error(photoSubmissionError.message);
+  }
+
   let payoutId: string;
 
   try {
@@ -112,6 +148,10 @@ export async function closeOutPayoutAction(formData: FormData) {
   } catch (error) {
     parentDashboardError(error instanceof Error ? error.message : "Could not close out payout.");
   }
+
+  await removeStoredChorePhotos(
+    photoSubmissions?.map((submission) => submission.photo_storage_path) ?? [],
+  );
 
   redirect(`/parent?paid=${payoutId}`);
 }
@@ -126,12 +166,23 @@ export async function deleteSubmissionPhotoAction(formData: FormData) {
   }
 
   const supabase = await createSupabaseServerClient();
+  const { data: submission, error: submissionError } = await supabase
+    .from("chore_submissions")
+    .select("photo_storage_path")
+    .eq("id", parsed.data.submissionId)
+    .maybeSingle();
+
+  if (submissionError) {
+    throw new Error(submissionError.message);
+  }
 
   try {
     await deleteSubmissionPhoto(supabase, parsed.data.submissionId);
   } catch (error) {
     parentDashboardError(error instanceof Error ? error.message : "Could not remove photo.");
   }
+
+  await removeStoredChorePhotos([submission?.photo_storage_path]);
 
   redirect("/parent?photoDeleted=1");
 }

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/app/parent/actions";
 import { ParentNav } from "@/components/parent-nav";
 import { getCurrentParentHouseholdId, requireCurrentProfile } from "@/lib/auth/session";
+import { CHORE_SUBMISSION_PHOTO_BUCKET } from "@/lib/supabase/chore-photo-storage";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -182,7 +183,7 @@ export default async function ParentHomePage({
       await Promise.all(
         photoSubmissions.map(async (submission) => {
           const { data } = await supabase.storage
-            .from("chore-submission-photos")
+            .from(CHORE_SUBMISSION_PHOTO_BUCKET)
             .createSignedUrl(submission.photo_storage_path ?? "", 600);
 
           return data?.signedUrl ? ([submission.id, data.signedUrl] as const) : null;

--- a/src/lib/supabase/chore-photo-storage.ts
+++ b/src/lib/supabase/chore-photo-storage.ts
@@ -1,0 +1,62 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "./database.types";
+import { createSupabaseServiceRoleClient } from "./server";
+
+export const CHORE_SUBMISSION_PHOTO_BUCKET = "chore-submission-photos";
+
+const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
+const PHOTO_EXTENSIONS = new Map([
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/webp", "webp"],
+  ["image/heic", "heic"],
+  ["image/heif", "heif"],
+]);
+
+type AppSupabaseClient = SupabaseClient<Database>;
+
+export function chorePhotoValidationError(file: File) {
+  if (file.size > MAX_PHOTO_BYTES) {
+    return "Photo proof must be 5 MB or smaller.";
+  }
+
+  if (!PHOTO_EXTENSIONS.has(file.type)) {
+    return "Photo proof must be a JPEG, PNG, WebP, HEIC, or HEIF image.";
+  }
+
+  return null;
+}
+
+export function chorePhotoStoragePath(profileId: string, instanceId: string, file: File) {
+  const extension = PHOTO_EXTENSIONS.get(file.type) ?? "jpg";
+  return `${profileId}/${instanceId}/${crypto.randomUUID()}.${extension}`;
+}
+
+export async function removeStoredChorePhotos(paths: Array<string | null | undefined>) {
+  const uniquePaths = [...new Set(paths.filter((path): path is string => Boolean(path)))];
+
+  if (!uniquePaths.length) {
+    return;
+  }
+
+  try {
+    const serviceRoleSupabase = createSupabaseServiceRoleClient();
+    const { error } = await serviceRoleSupabase.storage
+      .from(CHORE_SUBMISSION_PHOTO_BUCKET)
+      .remove(uniquePaths);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  } catch (error) {
+    console.error("Could not remove stored submission photos.", error);
+  }
+}
+
+export function createPhotoCleanupLookupClient(fallbackClient: AppSupabaseClient) {
+  try {
+    return createSupabaseServiceRoleClient();
+  } catch {
+    return fallbackClient;
+  }
+}


### PR DESCRIPTION
## Summary

- Centralizes chore submission photo storage constants, validation, path creation, and object removal helpers.
- Removes uploaded photo objects when kid submission RPC fails after upload, reducing orphaned storage objects.
- Removes stored photo objects after parent photo deletion and payout closeout mark submission photos deleted.
- Updates schema notes to document best-effort object cleanup and the remaining retry-job follow-up.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`

## Notes

Storage object deletion is best-effort from server actions. A retryable cleanup job is still the right follow-up for transient deletion failures.