### PR TITLE
[codex] Add Supabase chore expiration job

### DIFF
--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -1,0 +1,41 @@
+# Background Jobs
+
+## Decision
+
+Use Supabase-native scheduling for MVP background work.
+
+- Use Supabase Cron / `pg_cron` for recurring database jobs.
+- Use scheduled Edge Functions, triggered by Supabase Cron, for work that needs external APIs, object storage, or richer retry handling.
+- Keep command functions idempotent where possible so scheduled jobs can safely retry.
+
+Supabase Cron is built on the `pg_cron` Postgres extension:
+https://supabase.com/docs/guides/cron
+
+Supabase supports scheduled Edge Functions through `pg_cron` and `pg_net`:
+https://supabase.com/docs/guides/functions/schedule-functions
+
+## MVP Job Boundaries
+
+Run in Postgres through `pg_cron`:
+
+- Expire overdue chore instances.
+- Generate recurring chore instances.
+- Reconcile database-only cleanup markers.
+
+Run as scheduled Edge Functions:
+
+- Retry physical object deletion for chore photos.
+- Send push notifications and write inbox fallback events.
+- Future email delivery cleanup.
+
+## Implemented Jobs
+
+### `expire-overdue-chore-instances`
+
+Schedule: every 15 minutes.
+
+Calls `public.expire_overdue_chore_instances()`.
+
+The function marks open `assigned`, `available`, and `rejected` chore instances as `expired` after their due window closes. If an instance has no explicit `due_window_end`, it expires after the household-local occurrence day ends.
+
+The function returns the number of instances expired for observability in `cron.job_run_details`.

--- a/supabase/migrations/202605270002_expire_overdue_chores.sql
+++ b/supabase/migrations/202605270002_expire_overdue_chores.sql
@@ -1,0 +1,50 @@
+-- Scheduled expiration for missed chore instances.
+
+create extension if not exists pg_cron with schema extensions;
+
+create or replace function public.expire_overdue_chore_instances(
+  reference_time timestamptz default now()
+)
+returns int
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  expired_count int;
+begin
+  update public.chore_instances instance
+  set status = 'expired'
+  from public.households household
+  where household.id = instance.earning_household_id
+    and instance.status in ('assigned', 'available', 'rejected')
+    and (
+      (
+        instance.due_window_end is not null
+        and instance.due_window_end <= reference_time
+      )
+      or (
+        instance.due_window_end is null
+        and ((instance.occurrence_date + 1)::timestamp at time zone household.timezone) <= reference_time
+      )
+    );
+
+  get diagnostics expired_count = row_count;
+  return expired_count;
+end;
+$$;
+
+do $$
+begin
+  perform cron.unschedule('expire-overdue-chore-instances');
+exception
+  when others then
+    null;
+end;
+$$;
+
+select cron.schedule(
+  'expire-overdue-chore-instances',
+  '*/15 * * * *',
+  $$select public.expire_overdue_chore_instances();$$
+);

--- a/supabase/tests/expiration_smoke.sql
+++ b/supabase/tests/expiration_smoke.sql
@@ -1,0 +1,184 @@
+-- Local smoke test for scheduled chore expiration behavior.
+-- Run after `supabase db reset --local --no-seed`.
+
+do $$
+declare
+  parent_id uuid := '00000000-0000-4000-8000-000000000031';
+  child_id uuid := '00000000-0000-4000-8000-000000000032';
+  household_id uuid;
+  child_profile_id uuid;
+  target_template_id uuid;
+  expired_count int;
+begin
+  insert into auth.users (id, email, raw_user_meta_data, is_sso_user, is_anonymous)
+  values
+    (
+      parent_id,
+      'parent-expiration@example.test',
+      jsonb_build_object('app_role', 'parent', 'display_name', 'Parent'),
+      false,
+      false
+    ),
+    (
+      child_id,
+      'child-expiration@example.test',
+      jsonb_build_object('app_role', 'child', 'display_name', 'Child'),
+      false,
+      false
+    );
+
+  insert into public.households (name, timezone, created_by)
+  values ('Expiration Household', 'America/Chicago', parent_id)
+  returning id into household_id;
+
+  insert into public.household_memberships (household_id, user_id, role)
+  values
+    (household_id, parent_id, 'admin'),
+    (household_id, child_id, 'child');
+
+  insert into public.child_profiles (user_id, primary_household_id, created_by)
+  values (child_id, household_id, parent_id)
+  returning id into child_profile_id;
+
+  insert into public.chore_templates (
+    household_id,
+    created_by,
+    title,
+    schedule_type,
+    start_date,
+    one_off_date,
+    assignment_mode,
+    value_model,
+    amount_cents,
+    photo_required,
+    approval_required
+  )
+  values (
+    household_id,
+    parent_id,
+    'Expiration test chore',
+    'one_off',
+    '2026-05-01',
+    '2026-05-01',
+    'selected_children',
+    'unpaid',
+    0,
+    false,
+    true
+  )
+  returning id into target_template_id;
+
+  insert into public.chore_instances (
+    template_id,
+    earning_household_id,
+    assigned_child_profile_id,
+    occurrence_date,
+    due_window_end,
+    value_model_snapshot,
+    amount_cents_snapshot,
+    photo_required_snapshot,
+    approval_required_snapshot,
+    status,
+    up_for_grabs_slot
+  )
+  values
+    (
+      target_template_id,
+      household_id,
+      child_profile_id,
+      '2026-05-01',
+      '2026-05-01 18:00:00-05',
+      'unpaid',
+      0,
+      false,
+      true,
+      'assigned',
+      false
+    ),
+    (
+      target_template_id,
+      household_id,
+      null,
+      '2026-05-01',
+      '2026-05-01 18:00:00-05',
+      'unpaid',
+      0,
+      false,
+      true,
+      'available',
+      true
+    ),
+    (
+      target_template_id,
+      household_id,
+      child_profile_id,
+      '2026-04-30',
+      null,
+      'unpaid',
+      0,
+      false,
+      true,
+      'rejected',
+      false
+    ),
+    (
+      target_template_id,
+      household_id,
+      child_profile_id,
+      '2026-05-02',
+      '2026-05-03 18:00:00-05',
+      'unpaid',
+      0,
+      false,
+      true,
+      'assigned',
+      false
+    ),
+    (
+      target_template_id,
+      household_id,
+      child_profile_id,
+      '2026-04-29',
+      '2026-04-29 18:00:00-05',
+      'unpaid',
+      0,
+      false,
+      true,
+      'submitted',
+      false
+    );
+
+  expired_count := public.expire_overdue_chore_instances('2026-05-03 06:00:00-05');
+
+  if expired_count <> 3 then
+    raise exception 'Expected 3 expired chores, got %', expired_count;
+  end if;
+
+  if (
+    select count(*)
+    from public.chore_instances
+    where chore_instances.template_id = target_template_id
+      and status = 'expired'
+  ) <> 3 then
+    raise exception 'Expected exactly 3 expired instances';
+  end if;
+
+  if not exists (
+    select 1
+    from public.chore_instances
+    where chore_instances.template_id = target_template_id
+      and occurrence_date = '2026-05-02'
+      and status = 'assigned'
+  ) then
+    raise exception 'Expected future assigned chore to stay assigned';
+  end if;
+
+  if not exists (
+    select 1
+    from public.chore_instances
+    where chore_instances.template_id = target_template_id
+      and status = 'submitted'
+  ) then
+    raise exception 'Expected submitted chore to stay submitted';
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

- Documents the MVP background-job decision: Supabase Cron / `pg_cron` for database jobs, scheduled Edge Functions for storage/API-heavy work.
- Adds `public.expire_overdue_chore_instances()` to expire overdue assigned, available, and rejected chores.
- Schedules `expire-overdue-chore-instances` every 15 minutes through `pg_cron`.
- Adds a local SQL smoke test for expiration behavior.

## Validation

- `npm run typecheck`
- `npm test`
- `git diff --check`
- `supabase db reset --local --no-seed`
- `psql -f supabase/tests/expiration_smoke.sql`
- `supabase db lint`
- confirmed `expire-overdue-chore-instances` exists in `cron.job`

## Notes

This is the first database-side scheduled job. Physical photo cleanup retries and notifications should use scheduled Edge Functions in a later slice.