### PR TITLE
[codex] Add recurring chore generation job

### DIFF
--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -39,3 +39,13 @@ Calls `public.expire_overdue_chore_instances()`.
 The function marks open `assigned`, `available`, and `rejected` chore instances as `expired` after their due window closes. If an instance has no explicit `due_window_end`, it expires after the household-local occurrence day ends.
 
 The function returns the number of instances expired for observability in `cron.job_run_details`.
+
+### `generate-recurring-chore-instances`
+
+Schedule: hourly at minute 7.
+
+Calls `public.generate_chore_instances_for_range(current_date, current_date + 14)`.
+
+The function creates daily, weekly, and interval chore instances for selected-child, all-eligible-children, and up-for-grabs templates. Existing unique indexes make the job idempotent, so reruns skip already-created instances.
+
+Child-specific generation respects household availability windows and date overrides. When no availability window exists for a child, the child is treated as available so single-household setups do not require an availability pattern before chores can appear.

--- a/supabase/migrations/202605270003_generate_recurring_chore_instances.sql
+++ b/supabase/migrations/202605270003_generate_recurring_chore_instances.sql
@@ -1,0 +1,309 @@
+-- Scheduled recurring chore instance generation.
+
+create or replace function public.is_child_available_for_household_on(
+  target_child_profile_id uuid,
+  target_household_id uuid,
+  target_date date
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with override_match as (
+    select availability_override.available
+    from public.child_household_availability_overrides availability_override
+    where availability_override.child_profile_id = target_child_profile_id
+      and availability_override.household_id = target_household_id
+      and availability_override.override_date = target_date
+    limit 1
+  ),
+  window_match as (
+    select
+      availability_window.anchor_date,
+      availability_window.cycle_length_days,
+      availability_window.available_day_offsets,
+      availability_window.starts_on,
+      availability_window.ends_on
+    from public.child_household_availability_windows availability_window
+    where availability_window.child_profile_id = target_child_profile_id
+      and availability_window.household_id = target_household_id
+    limit 1
+  )
+  select coalesce(
+    (select override_match.available from override_match),
+    (
+      select
+        (window_match.starts_on is null or target_date >= window_match.starts_on)
+        and (window_match.ends_on is null or target_date <= window_match.ends_on)
+        and (
+          (
+            ((target_date - window_match.anchor_date) % window_match.cycle_length_days)
+            + window_match.cycle_length_days
+          ) % window_match.cycle_length_days
+        ) = any(window_match.available_day_offsets)
+      from window_match
+    ),
+    true
+  )
+$$;
+
+create or replace function public.generate_chore_instances_for_range(
+  range_start date default current_date,
+  range_end date default current_date + 14
+)
+returns int
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  inserted_count int := 0;
+  batch_count int := 0;
+begin
+  if range_start is null or range_end is null then
+    raise exception 'Generation range is required';
+  end if;
+
+  if range_start > range_end then
+    raise exception 'Generation range start must be on or before range end';
+  end if;
+
+  insert into public.chore_instances (
+    template_id,
+    earning_household_id,
+    assigned_child_profile_id,
+    occurrence_date,
+    due_window_start,
+    due_window_end,
+    value_model_snapshot,
+    amount_cents_snapshot,
+    photo_required_snapshot,
+    approval_required_snapshot,
+    status
+  )
+  select
+    template.id,
+    template.household_id,
+    assignee.child_profile_id,
+    occurrence.occurrence_date::date,
+    case
+      when template.due_time_start is null then null
+      else public.combine_chore_due_window(
+        template.household_id,
+        occurrence.occurrence_date::date,
+        template.due_time_start
+      )
+    end,
+    case
+      when template.due_time_end is null then null
+      else public.combine_chore_due_window(
+        template.household_id,
+        occurrence.occurrence_date::date,
+        template.due_time_end
+      )
+    end,
+    template.value_model,
+    template.amount_cents,
+    template.photo_required,
+    template.approval_required,
+    'assigned'::public.chore_instance_status
+  from public.chore_templates template
+  join generate_series(range_start, range_end, interval '1 day') occurrence(occurrence_date)
+    on true
+  join public.chore_template_assignees assignee
+    on assignee.template_id = template.id
+  where template.active
+    and template.assignment_mode = 'selected_children'
+    and template.schedule_type in ('daily', 'weekly', 'interval')
+    and occurrence.occurrence_date::date >= template.start_date
+    and (template.end_date is null or occurrence.occurrence_date::date <= template.end_date)
+    and (
+      template.schedule_type = 'daily'
+      or (
+        template.schedule_type = 'weekly'
+        and extract(dow from occurrence.occurrence_date::date)::int = any(template.weekly_weekdays)
+      )
+      or (
+        template.schedule_type = 'interval'
+        and ((occurrence.occurrence_date::date - template.start_date) % template.interval_days) = 0
+      )
+    )
+    and public.is_child_available_for_household_on(
+      assignee.child_profile_id,
+      template.household_id,
+      occurrence.occurrence_date::date
+    )
+  on conflict do nothing;
+
+  get diagnostics batch_count = row_count;
+  inserted_count := inserted_count + batch_count;
+
+  insert into public.chore_instances (
+    template_id,
+    earning_household_id,
+    assigned_child_profile_id,
+    occurrence_date,
+    due_window_start,
+    due_window_end,
+    value_model_snapshot,
+    amount_cents_snapshot,
+    photo_required_snapshot,
+    approval_required_snapshot,
+    status
+  )
+  select
+    template.id,
+    template.household_id,
+    child.id,
+    occurrence.occurrence_date::date,
+    case
+      when template.due_time_start is null then null
+      else public.combine_chore_due_window(
+        template.household_id,
+        occurrence.occurrence_date::date,
+        template.due_time_start
+      )
+    end,
+    case
+      when template.due_time_end is null then null
+      else public.combine_chore_due_window(
+        template.household_id,
+        occurrence.occurrence_date::date,
+        template.due_time_end
+      )
+    end,
+    template.value_model,
+    template.amount_cents,
+    template.photo_required,
+    template.approval_required,
+    'assigned'::public.chore_instance_status
+  from public.chore_templates template
+  join generate_series(range_start, range_end, interval '1 day') occurrence(occurrence_date)
+    on true
+  join public.household_memberships membership
+    on membership.household_id = template.household_id
+   and membership.role = 'child'
+  join public.child_profiles child
+    on child.user_id = membership.user_id
+  where template.active
+    and template.assignment_mode = 'all_eligible_children'
+    and template.schedule_type in ('daily', 'weekly', 'interval')
+    and occurrence.occurrence_date::date >= template.start_date
+    and (template.end_date is null or occurrence.occurrence_date::date <= template.end_date)
+    and (
+      template.schedule_type = 'daily'
+      or (
+        template.schedule_type = 'weekly'
+        and extract(dow from occurrence.occurrence_date::date)::int = any(template.weekly_weekdays)
+      )
+      or (
+        template.schedule_type = 'interval'
+        and ((occurrence.occurrence_date::date - template.start_date) % template.interval_days) = 0
+      )
+    )
+    and public.is_child_available_for_household_on(
+      child.id,
+      template.household_id,
+      occurrence.occurrence_date::date
+    )
+  on conflict do nothing;
+
+  get diagnostics batch_count = row_count;
+  inserted_count := inserted_count + batch_count;
+
+  insert into public.chore_instances (
+    template_id,
+    earning_household_id,
+    occurrence_date,
+    due_window_start,
+    due_window_end,
+    value_model_snapshot,
+    amount_cents_snapshot,
+    photo_required_snapshot,
+    approval_required_snapshot,
+    status,
+    up_for_grabs_slot
+  )
+  select
+    template.id,
+    template.household_id,
+    occurrence.occurrence_date::date,
+    case
+      when template.due_time_start is null then null
+      else public.combine_chore_due_window(
+        template.household_id,
+        occurrence.occurrence_date::date,
+        template.due_time_start
+      )
+    end,
+    case
+      when template.due_time_end is null then null
+      else public.combine_chore_due_window(
+        template.household_id,
+        occurrence.occurrence_date::date,
+        template.due_time_end
+      )
+    end,
+    template.value_model,
+    template.amount_cents,
+    template.photo_required,
+    template.approval_required,
+    'available'::public.chore_instance_status,
+    true
+  from public.chore_templates template
+  join generate_series(range_start, range_end, interval '1 day') occurrence(occurrence_date)
+    on true
+  where template.active
+    and template.assignment_mode = 'up_for_grabs'
+    and template.schedule_type in ('daily', 'weekly', 'interval')
+    and occurrence.occurrence_date::date >= template.start_date
+    and (template.end_date is null or occurrence.occurrence_date::date <= template.end_date)
+    and (
+      template.schedule_type = 'daily'
+      or (
+        template.schedule_type = 'weekly'
+        and extract(dow from occurrence.occurrence_date::date)::int = any(template.weekly_weekdays)
+      )
+      or (
+        template.schedule_type = 'interval'
+        and ((occurrence.occurrence_date::date - template.start_date) % template.interval_days) = 0
+      )
+    )
+    and exists (
+      select 1
+      from public.household_memberships membership
+      join public.child_profiles child
+        on child.user_id = membership.user_id
+      where membership.household_id = template.household_id
+        and membership.role = 'child'
+        and public.is_child_available_for_household_on(
+          child.id,
+          template.household_id,
+          occurrence.occurrence_date::date
+        )
+    )
+  on conflict do nothing;
+
+  get diagnostics batch_count = row_count;
+  inserted_count := inserted_count + batch_count;
+
+  return inserted_count;
+end;
+$$;
+
+do $$
+begin
+  perform cron.unschedule('generate-recurring-chore-instances');
+exception
+  when others then
+    null;
+end;
+$$;
+
+select cron.schedule(
+  'generate-recurring-chore-instances',
+  '7 * * * *',
+  $$select public.generate_chore_instances_for_range(current_date, current_date + 14);$$
+);

--- a/supabase/tests/recurring_generation_smoke.sql
+++ b/supabase/tests/recurring_generation_smoke.sql
@@ -1,0 +1,221 @@
+-- Local smoke test for scheduled recurring chore instance generation.
+-- Run after `supabase db reset --local --no-seed`.
+
+do $$
+declare
+  parent_id uuid := '00000000-0000-4000-8000-000000000041';
+  child_one_id uuid := '00000000-0000-4000-8000-000000000042';
+  child_two_id uuid := '00000000-0000-4000-8000-000000000043';
+  household_id uuid;
+  child_one_profile_id uuid;
+  child_two_profile_id uuid;
+  weekly_template_id uuid;
+  grabs_template_id uuid;
+  inserted_count int;
+begin
+  insert into auth.users (id, email, raw_user_meta_data, is_sso_user, is_anonymous)
+  values
+    (
+      parent_id,
+      'parent-recurring@example.test',
+      jsonb_build_object('app_role', 'parent', 'display_name', 'Parent'),
+      false,
+      false
+    ),
+    (
+      child_one_id,
+      'child-one-recurring@example.test',
+      jsonb_build_object('app_role', 'child', 'display_name', 'Child One'),
+      false,
+      false
+    ),
+    (
+      child_two_id,
+      'child-two-recurring@example.test',
+      jsonb_build_object('app_role', 'child', 'display_name', 'Child Two'),
+      false,
+      false
+    );
+
+  insert into public.households (name, timezone, created_by)
+  values ('Recurring Household', 'America/Chicago', parent_id)
+  returning id into household_id;
+
+  insert into public.household_memberships (household_id, user_id, role)
+  values
+    (household_id, parent_id, 'admin'),
+    (household_id, child_one_id, 'child'),
+    (household_id, child_two_id, 'child');
+
+  insert into public.child_profiles (user_id, primary_household_id, created_by)
+  values (child_one_id, household_id, parent_id)
+  returning id into child_one_profile_id;
+
+  insert into public.child_profiles (user_id, primary_household_id, created_by)
+  values (child_two_id, household_id, parent_id)
+  returning id into child_two_profile_id;
+
+  insert into public.child_household_availability_windows (
+    child_profile_id,
+    child_user_id,
+    household_id,
+    anchor_date,
+    cycle_length_days,
+    available_day_offsets,
+    created_by
+  )
+  values
+    (
+      child_one_profile_id,
+      child_one_id,
+      household_id,
+      '2026-06-01',
+      7,
+      array[0, 2],
+      parent_id
+    ),
+    (
+      child_two_profile_id,
+      child_two_id,
+      household_id,
+      '2026-06-01',
+      7,
+      array[0, 2],
+      parent_id
+    );
+
+  insert into public.child_household_availability_overrides (
+    child_profile_id,
+    child_user_id,
+    household_id,
+    override_date,
+    available,
+    reason,
+    created_by
+  )
+  values (
+    child_two_profile_id,
+    child_two_id,
+    household_id,
+    '2026-06-03',
+    false,
+    'Travel',
+    parent_id
+  );
+
+  insert into public.chore_templates (
+    household_id,
+    created_by,
+    title,
+    schedule_type,
+    start_date,
+    weekly_weekdays,
+    due_time_start,
+    due_time_end,
+    assignment_mode,
+    value_model,
+    amount_cents,
+    photo_required,
+    approval_required
+  )
+  values (
+    household_id,
+    parent_id,
+    'Weekly counters',
+    'weekly',
+    '2026-06-01',
+    array[1, 3],
+    '17:00',
+    '20:00',
+    'selected_children',
+    'unpaid',
+    0,
+    false,
+    true
+  )
+  returning id into weekly_template_id;
+
+  insert into public.chore_template_assignees (template_id, child_profile_id)
+  values
+    (weekly_template_id, child_one_profile_id),
+    (weekly_template_id, child_two_profile_id);
+
+  insert into public.chore_templates (
+    household_id,
+    created_by,
+    title,
+    schedule_type,
+    start_date,
+    weekly_weekdays,
+    assignment_mode,
+    value_model,
+    amount_cents,
+    photo_required,
+    approval_required
+  )
+  values (
+    household_id,
+    parent_id,
+    'Grab the mail',
+    'weekly',
+    '2026-06-01',
+    array[1, 3],
+    'up_for_grabs',
+    'unpaid',
+    0,
+    false,
+    true
+  )
+  returning id into grabs_template_id;
+
+  inserted_count := public.generate_chore_instances_for_range('2026-06-01', '2026-06-07');
+
+  if inserted_count <> 5 then
+    raise exception 'Expected 5 generated instances, got %', inserted_count;
+  end if;
+
+  if public.generate_chore_instances_for_range('2026-06-01', '2026-06-07') <> 0 then
+    raise exception 'Expected second generation pass to be idempotent';
+  end if;
+
+  if (
+    select count(*)
+    from public.chore_instances instance
+    where instance.template_id = weekly_template_id
+      and instance.status = 'assigned'
+  ) <> 3 then
+    raise exception 'Expected 3 selected-child weekly instances';
+  end if;
+
+  if exists (
+    select 1
+    from public.chore_instances instance
+    where instance.template_id = weekly_template_id
+      and instance.assigned_child_profile_id = child_two_profile_id
+      and instance.occurrence_date = '2026-06-03'
+  ) then
+    raise exception 'Expected child availability override to skip June 3';
+  end if;
+
+  if (
+    select count(*)
+    from public.chore_instances instance
+    where instance.template_id = grabs_template_id
+      and instance.status = 'available'
+      and instance.up_for_grabs_slot
+  ) <> 2 then
+    raise exception 'Expected one up-for-grabs slot per occurrence';
+  end if;
+
+  if not exists (
+    select 1
+    from public.chore_instances instance
+    where instance.template_id = weekly_template_id
+      and instance.assigned_child_profile_id = child_one_profile_id
+      and instance.occurrence_date = '2026-06-03'
+      and instance.due_window_start = '2026-06-03 17:00:00 America/Chicago'::timestamptz
+      and instance.due_window_end = '2026-06-03 20:00:00 America/Chicago'::timestamptz
+  ) then
+    raise exception 'Expected household-local due window snapshots';
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

- Adds `public.is_child_available_for_household_on(...)` for date-specific custody availability checks.
- Adds `public.generate_chore_instances_for_range(...)` for daily, weekly, and interval recurring templates.
- Supports selected-child, all-eligible-children, and up-for-grabs recurring generation.
- Schedules `generate-recurring-chore-instances` hourly through Supabase Cron.
- Adds a SQL smoke test for generation, availability overrides, idempotency, due-window snapshots, and up-for-grabs slots.
- Updates background job docs with the new scheduled job.

## Validation

- `npm run typecheck`
- `npm test`
- `git diff --check`
- `supabase db reset --local --no-seed`
- `psql -f supabase/tests/recurring_generation_smoke.sql`
- `supabase db lint`
- confirmed both cron jobs exist in `cron.job`

## Notes

The generator treats children without an availability window as available, so simple single-household setups can generate chores before parents configure custody patterns.